### PR TITLE
Added new database health route with metrics and type

### DIFF
--- a/apps/server/api/internal/app.go
+++ b/apps/server/api/internal/app.go
@@ -50,6 +50,9 @@ func GetSystemHealth(c fiber.Ctx) error {
 	})
 }
 
+// TODO: Add authentication middleware to protect this endpoint in production
+// Thus making sure only authorized admins can access it
+// Currently it's only available in development mode because of this issue
 func GetDatabaseHealth(c fiber.Ctx) error {
 	now := time.Now()
 	if err := services.Ping(); err != nil {

--- a/apps/server/api/internal/app.go
+++ b/apps/server/api/internal/app.go
@@ -50,6 +50,19 @@ func GetSystemHealth(c fiber.Ctx) error {
 	})
 }
 
+func GetDatabaseHealth(c fiber.Ctx) error {
+	now := time.Now()
+	if err := services.Ping(); err != nil {
+		return response.ServiceUnavailable(c, "Database connection error: "+err.Error())
+	}
+
+	return response.Success(c, types.DatabaseHealthResponse{
+		Status:  "ok",
+		Message: "Database connection is healthy",
+		Elapsed: time.Since(now).String(),
+	})
+}
+
 func NotFoundHandler(c fiber.Ctx) error {
 	return response.NotFound(c, "The requested resource was not found.")
 }

--- a/apps/server/api/routes/app.go
+++ b/apps/server/api/routes/app.go
@@ -2,10 +2,15 @@ package routes
 
 import (
 	"github.com/MonkyMars/PWS/api/internal"
+	"github.com/MonkyMars/PWS/config"
 	"github.com/gofiber/fiber/v3"
 )
 
 func SetupAppRoutes(app *fiber.App) {
-	app.Get("/health", internal.GetSystemHealth)
+	cfg := config.Get()
+	if cfg.Environment == "development" {
+		app.Get("/health", internal.GetSystemHealth)
+		app.Get("/health/database", internal.GetDatabaseHealth)
+	}
 	app.Use(internal.NotFoundHandler)
 }

--- a/apps/server/types/app.go
+++ b/apps/server/types/app.go
@@ -13,3 +13,9 @@ type HealthMetrics struct {
 	GoRoutines    int     `json:"go_routines"`
 	RequestCount  int64   `json:"request_count,omitempty"`
 }
+
+type DatabaseHealthResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+	Elapsed string `json:"elapsed,omitempty"`
+}


### PR DESCRIPTION
This pull request introduces a new endpoint for checking database health, which is only available in the development environment. The main changes include the addition of a health check handler for the database, updates to route setup to conditionally expose this endpoint, and the creation of a response type for database health status.

**New Database Health Check Feature:**

* Added a `GetDatabaseHealth` handler in `apps/server/api/internal/app.go` to check the database connection and return its status, message, and elapsed time.
* Defined the `DatabaseHealthResponse` struct in `apps/server/types/app.go` to standardize the response format for database health checks.

**Development Environment Routing:**

* Updated `apps/server/api/routes/app.go` to expose `/health/database` and `/health` endpoints only when the environment is set to development, ensuring these diagnostics are not available in production.