### PR TITLE
Add a pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# IMPORTANT: Use this template for all PRs to ensure consistency.
+You can remove sections that do not apply to your change.
+
+## Description & Motivation
+- What does this PR do?
+- Why is this change needed (context, user story, bug reference)?
+- Any relevant background or links (design docs, discussions, specs).
+
+## Related Issues
+Closes #<issue_number>
+Relates to #<other_issue_number>
+
+*(Only include “Closes” for issues you intend this PR to fully resolve.)*
+
+## Scope of Change
+*(Mark or list the relevant ones)*
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] Breaking change


### PR DESCRIPTION
This pull request introduces a new standardized template for pull requests to improve consistency and clarity in PR submissions.

Documentation improvements:

* Added `.github/pull_request_template.md` to provide a structured format for describing PRs, including sections for description, motivation, related issues, and scope of change.