### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # Lightning-fast parallel builds with comprehensive tooling
   build-and-test:


### PR DESCRIPTION
Potential fix for [https://github.com/MonkyMars/PWS/security/code-scanning/6](https://github.com/MonkyMars/PWS/security/code-scanning/6)

To fix the problem, the workflow YAML file should include a `permissions:` block that sets explicit/scoped permissions for jobs, preferably at the workflow level so that all jobs inherit restricted permissions unless overridden for specific jobs that require more. Since most steps in the shown workflow only read code or produce summaries, a minimal set of permissions such as `contents: read` is typically enough. If any job writes pull-requests or issues, those scopes can be added, but for this workflow, read access will suffice as a starting point.

The fix: Add a `permissions:` block at the top level (immediately after the `name:` and `on:` blocks, before `jobs:`) with the value `contents: read`. This restricts the `GITHUB_TOKEN` to read-only access to repository contents for all jobs, following least privilege guidelines. If any job later needs more permissions, scopes can be added under that job.

Required changes: In `.github/workflows/ci.yml`, insert the following lines at the appropriate location:
```yaml
permissions:
  contents: read
```

No new library imports or method/variable definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
