### PR TITLE
Remove go.sum from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ build/
 .env.local
 
 *.log
-go.sum
 
 # Exlude binary files
 bin/


### PR DESCRIPTION
Remove go.sum from .gitignore to track changes.

# IMPORTANT: Use this template for all PRs to ensure consistency.
You can remove sections that do not apply to your change.

## Description & Motivation
This pull request makes sure go.sum is present in `apps/server`. This is needed for ci/cd pipelines and fellow developers.

## Related Issues
Closes #47

## Scope of Change
*(Mark or list the relevant ones)*
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Breaking change
