### PR TITLE
Improve docker build speeds with cache and move en v to docker-compose

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -6,29 +6,29 @@ RUN apk add --no-cache git
 
 WORKDIR /app
 
-# Cache modules first
-COPY go.mod go.sum ./
-RUN go mod download
+# Cache dependencies separately
+COPY go.mod .
+COPY go.sum .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy source
+# Copy source code
 COPY . .
 
-# Build with optimizations
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o server ./main.go
+# Build binary with cache
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o server ./main.go
 
 # --- Stage 2: Minimal runtime image ---
 FROM alpine:3.20
 
 WORKDIR /app
 
-# Copy binary
+# Copy binary from builder stage
 COPY --from=builder /app/server .
-
-# Copy env file (or mount with docker-compose)
-COPY .env .env
 
 # Fiber runs on port 8082
 EXPOSE 8082
 
-# Run
 CMD ["./server"]

--- a/apps/server/docker-compose.yml
+++ b/apps/server/docker-compose.yml
@@ -1,9 +1,20 @@
 services:
   fiber-app:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: fiber_app
     env_file:
       - .env
+    volumes:
+      - .env:/app/.env:ro
+      # Cache Go build + module deps
+      - go-build-cache:/root/.cache/go-build
+      - go-mod-cache:/go/pkg/mod
     ports:
       - "8082:8082"
     restart: unless-stopped
+
+volumes:
+  go-build-cache:
+  go-mod-cache:


### PR DESCRIPTION
# IMPORTANT: Use this template for all PRs to ensure consistency.
You can remove sections that do not apply to your change.

## Description & Motivation
This pr speeds up docker builds with cache and not baking in the .env file.
This improved DX:)

## Scope of Change
*(Mark or list the relevant ones)*
- [x] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Breaking change
